### PR TITLE
Preserve the background when converting to png

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -33,7 +33,6 @@ def convert_single(input_img, output_name, output_dir, base_size,
         if input_img.lower().endswith('.svg'):
             pRecons = subprocess.Popen([
                 'convert',
-                '-background', 'none',
                 '-density', '512',
                 '-gravity', 'center',
                 '-scale', '80%',


### PR DESCRIPTION
I can well imagine that many SVGs are designed to be transparent, but I’m not
sure how that’s supposed to work for app icons. In my testing, when my white
background was stripped, the icon was placed on a black background (by iOS)
which didn’t work for my colors. I think it’s probably safer to preserve the
background? Curious how it might work otherwise.